### PR TITLE
Removing dependency in kmgmt-common on slate

### DIFF
--- a/kmgmt/kmgmt-common/package.json
+++ b/kmgmt/kmgmt-common/package.json
@@ -19,8 +19,7 @@
     "loglevel": "^1.6.8",
     "react-native-reanimated": "~1.9.0",
     "react-native-safe-area-context": "~3.0.7",
-    "react-native-screens": "~2.9.0",
-    "slate": "^0.58.4"
+    "react-native-screens": "~2.9.0"
   },
   "devDependencies": {
     "@types/node": "^14.0.27",

--- a/kmgmt/kmgmt-common/src/Database.ts
+++ b/kmgmt/kmgmt-common/src/Database.ts
@@ -1,6 +1,18 @@
-import { Node as SlateNode } from "slate";
+// Taken from Slate type definitions
+export interface Text {
+  text: string;
+  [key: string]: unknown;
+}
 
-export type RichText = SlateNode[];
+export interface Element {
+  children: Node[];
+  [key: string]: unknown;
+}
+
+export declare type Node = Element | Text;
+
+export type RichText = Node[];
+
 export type NoteID = string;
 
 export interface NoteRecord {


### PR DESCRIPTION
There should be no more deps on `slate` from `kmgmt-common`.

The fields being saved/loaded from Firestore will be restricted according to the types defined in `Database.ts`. The `[key: string]: unknown` fields will be useful for metadata we may want to add to parts of the text.