### PR TITLE
Fix for On page load/reload, the text for 404 shows up briefly as auth state is being set up

### DIFF
--- a/village/village-web/src/App.tsx
+++ b/village/village-web/src/App.tsx
@@ -86,7 +86,7 @@ function App() {
   const [user, setUser] = useState<UserRecord>();
   useEffect(() => {
     const fetchUser = async () => {
-      if (authState?.uid) {
+      if (!!authState) {
         const user = await getUser(database)(authState.uid);
         if (user != null) {
           logger.debug(`setting user ${user.displayName}`);
@@ -96,7 +96,7 @@ function App() {
       }
     };
     fetchUser();
-  }, [authState?.uid, logger]);
+  }, [authState, logger]);
 
   authProvider.onAuthStateChanged = makeOnAuthStateChanged(
     authState,


### PR DESCRIPTION
See https://www.notion.so/On-page-load-reload-the-text-for-404-shows-up-briefly-as-auth-state-is-being-set-up-64a48b9653cc4b89b3ef2ae2564c7bb8.