### PR TITLE
Fix for incorrect prompt on empty read-only post

### DIFF
--- a/village/village-web/src/components/richtext/RichTextEditor.tsx
+++ b/village/village-web/src/components/richtext/RichTextEditor.tsx
@@ -136,7 +136,7 @@ const RichTextEditor = forwardRef<
       <EditablePlugins
         plugins={plugins}
         readOnly={props.readOnly ?? false}
-        placeholder="Enter some text"
+        placeholder={props.readOnly ? "Nothing here yet" : "Enter some text"}
         autoFocus
         spellCheck={false}
         onKeyDown={[onKeyDownMention]}


### PR DESCRIPTION
https://www.notion.so/Enter-some-text-prompt-in-PostView-body-should-not-be-visible-in-readOnly-mode-4ace332c8ca64e6a80f40213c4286655