### PR TITLE
Fix for infinite redirect between a PrivateRoute and /login upon first login

### DIFF
--- a/village/village-web/src/routing/PrivateRoute.tsx
+++ b/village/village-web/src/routing/PrivateRoute.tsx
@@ -25,7 +25,7 @@ export default function PrivateRoute(props: RouteProps) {
             <Redirect
               to={{
                 pathname: "/login",
-                state: { from: location },
+                state: { from: location, isPrivate: true },
               }}
             />
           );


### PR DESCRIPTION
This was happening because there was a race condition in setting up logged in state, during which `PrivateRoute` would redirect back to `/login` repeatedly.