### PR TITLE
All emulator usage controlled consistently by a single flag in App.tsx

### DIFF
--- a/village/village-web/src/App.tsx
+++ b/village/village-web/src/App.tsx
@@ -40,7 +40,8 @@ import { LoginView } from "./views/LoginView";
 
 Logging.configure(log);
 
-const useEmulator = window.location.hostname === "localhost";
+const isRunningLocally = window.location.hostname === "localhost";
+const useEmulator = isRunningLocally && false;
 
 const [app, auth, functions] = initializeFirebaseApp(useEmulator);
 const authProvider = FirebaseAuthProvider.create(app, auth);

--- a/village/village-web/src/services/Firebase.ts
+++ b/village/village-web/src/services/Firebase.ts
@@ -33,7 +33,7 @@ export const initializeFirebaseApp = (
 
     // TODO: Enable Auth emulator once available
     const DEFAULT_AUTH_EMULATOR_URL = "http://localhost:9099/";
-    const AUTH_EMULATOR_ENABLED = false; // see https://linear.app/bullfrog/issue/BUL-48#comment-7c0452cf
+    const AUTH_EMULATOR_ENABLED = false; // see https://github.com/firebase/firebaseui-web-react/pull/125#issuecomment-798798119
     if (AUTH_EMULATOR_ENABLED && !!useEmulator) {
       logger.debug(`using auth emulator at ${DEFAULT_AUTH_EMULATOR_URL}`);
       auth.useEmulator(DEFAULT_AUTH_EMULATOR_URL);

--- a/village/village-web/src/services/store/FirestoreDatabase.ts
+++ b/village/village-web/src/services/store/FirestoreDatabase.ts
@@ -10,15 +10,13 @@ export class FirestoreDatabase implements Database {
     this.firestore = firestore;
     this.logger.debug("created FirestoreDatabase");
 
-    // TODO: Enable Firestore emulator once available.
     const STORE_EMULATOR_HOSTNAME = "localhost";
-    const STORE_EMULATOR_PORT = "8080";
-    const STORE_EMULATOR_ENABLED = false; // see https://linear.app/bullfrog/issue/BUL-48#comment-7c0452cf
-    if (STORE_EMULATOR_ENABLED && !!useEmulator) {
+    const STORE_EMULATOR_PORT = 8080;
+    if (!!useEmulator) {
       this.logger.debug(
         `using store emulator at ${STORE_EMULATOR_HOSTNAME}:${STORE_EMULATOR_PORT}`
       );
-      // firestore.useEmulator(STORE_EMULATOR_HOSTNAME, STORE_EMULATOR_PORT); // only availble in firebase>=8.0.0
+      firestore.useEmulator(STORE_EMULATOR_HOSTNAME, STORE_EMULATOR_PORT); // only availble in firebase>=8.0.0
     }
   }
 


### PR DESCRIPTION
Emulator usage was being set inconsistently. This is fixed by having it set in a single place in `App.tsx`.